### PR TITLE
Add slow clock bypass

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -321,6 +321,13 @@ config CONFIG_SCLK
 	help
 	  Use external 32KHZ oscillator as source of slow clock
 
+config CONFIG_SCLK_BYPASS
+	depends on CONFIG_SCLK
+	bool "Use external 32kHz clock as source of slow clock"
+	default n
+	help
+	  Use external 32kHz clock as source of slow clock
+
 config CONFIG_DISABLE_WATCHDOG
 	bool "Disable Watchdog"
 	default y

--- a/board/board_cpp.mk
+++ b/board/board_cpp.mk
@@ -22,6 +22,10 @@ ifeq ($(CONFIG_SCLK),y)
 CPPFLAGS += -DCONFIG_SCLK
 endif
 
+ifeq ($(CONFIG_SCLK_BYPASS),y)
+CPPFLAGS += -DCONFIG_SCLK_BYPASS
+endif
+
 # Crystal frequency
 
 ifeq ($(CONFIG_CRYSTAL_12_000MHZ),y)

--- a/driver/at91_slowclk.c
+++ b/driver/at91_slowclk.c
@@ -52,9 +52,9 @@ int slowclk_switch_osc32(void)
 
 	/*
 	 * Wait 32768 Hz Startup Time for clock stabilization (software loop)
-	 * wait about 1s (1000ms)
+	 * wait about 1s (1300ms)
 	 */
-	wait_interval_timer(1000);
+	wait_interval_timer(1300);
 
 	/*
 	 * Switching from internal 32kHz RC oscillator to 32768 Hz oscillator
@@ -76,6 +76,19 @@ int slowclk_switch_osc32(void)
 	reg = readl(AT91C_BASE_SCKCR);
 	reg &= ~AT91C_SLCKSEL_RCEN;
 	writel(reg, AT91C_BASE_SCKCR);
+
+	/*
+	 * Bypass the 32kHz oscillator by using an external clock
+	 */
+#ifdef CONFIG_SCLK_BYPASS
+	reg = readl(AT91C_BASE_SCKCR);
+	reg |= AT91C_SLCKSEL_OSC32BYP;
+	writel(reg, AT91C_BASE_SCKCR);
+
+	reg = readl(AT91C_BASE_SCKCR);
+	reg &= ~AT91C_SLCKSEL_OSC32EN;
+	writel(reg, AT91C_BASE_SCKCR);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
If the slow clock is setup to use an external clock to provide the
32768Hz frequency, it is mandatory to bypass the crystal oscillator.
Failing to do so makes the board unbootable.

Signed-off-by: David Vincent freesilicon@gmail.com
