### PR TITLE
lib: div: remove check for dividend is 0x80000000

### DIFF
--- a/lib/div.c
+++ b/lib/div.c
@@ -36,9 +36,6 @@ int division(unsigned int dividend,
 	unsigned int factor = 0;
 	unsigned char end_flag = 0;
 
-	if (dividend & 0x80000000)
-		return 0xffffffff;
-
 	if (!divisor)
 		return 0xffffffff;
 


### PR DESCRIPTION
As the dividend is unsigned int, so it can be 0x80000000.

Signed-off-by: Bo Shen voice.shen@gmail.com
