### PR TITLE
sama5d3xek: Take into account the Android kernel bootarg config option

### DIFF
--- a/board/sama5d3xek/Config.in.android_arg
+++ b/board/sama5d3xek/Config.in.android_arg
@@ -1,3 +1,3 @@
 config CONFIG_LINUX_KERNEL_ARG_STRING
-	default "console=ttyS0,115200 mtdparts=atmel_nand:5M(Bootstrap),125M(system),-(userdata) ubi.mtd=1 ubi.mtd=2 rw root=ubi0:system rootfstype=ubifs init=/init androidboot.hardware=sama5d3x-ek androidboot.console=ttyS0" if CONFIG_SAMA5D3XEK && !CONFIG_SDCARD
-	default "console=ttyS0,115200 root=/dev/mmcblk0p2 rw rootwait init=/init androidboot.hardware=sama5d3x-ek androidboot.console=ttyS0" if CONFIG_SAMA5D3XEK && CONFIG_SDCARD
+	default "console=ttyS0,115200 mtdparts=atmel_nand:5M(Bootstrap),125M(system),-(userdata) ubi.mtd=1 ubi.mtd=2 rw root=ubi0:system rootfstype=ubifs init=/init androidboot.console=ttyS0" if CONFIG_SAMA5D3XEK && !CONFIG_SDCARD
+	default "console=ttyS0,115200 root=/dev/mmcblk0p2 rw rootwait init=/init androidboot.console=ttyS0" if CONFIG_SAMA5D3XEK && CONFIG_SDCARD

--- a/board/sama5d3xek/sama5d3xeknf_android_uimage_dt_defconfig
+++ b/board/sama5d3xek/sama5d3xeknf_android_uimage_dt_defconfig
@@ -117,7 +117,7 @@ CONFIG_LINUX_UIMAGE=y
 # CONFIG_LINUX_ZIMAGE is not set
 CONFIG_MEM_BANK="0x20000000"
 CONFIG_MEM_SIZE="0x20000000"
-CONFIG_LINUX_KERNEL_ARG_STRING="console=ttyS0,115200 mtdparts=atmel_nand:5M(Bootstrap),125M(system),-(userdata) ubi.mtd=1 ubi.mtd=2 rw root=ubi0:system rootfstype=ubifs init=/init androidboot.hardware=sama5d3x-ek androidboot.console=ttyS0"
+CONFIG_LINUX_KERNEL_ARG_STRING="console=ttyS0,115200 mtdparts=atmel_nand:5M(Bootstrap),125M(system),-(userdata) ubi.mtd=1 ubi.mtd=2 rw root=ubi0:system rootfstype=ubifs init=/init androidboot.console=ttyS0"
 CONFIG_IMG_ADDRESS="0x00200000"
 CONFIG_JUMP_ADDR="0x22000000"
 CONFIG_OF_LIBFDT=y

--- a/board/sama5d3xek/sama5d3xeknf_android_zimage_dt_defconfig
+++ b/board/sama5d3xek/sama5d3xeknf_android_zimage_dt_defconfig
@@ -117,7 +117,7 @@ CONFIG_LOAD_ANDROID=y
 CONFIG_LINUX_ZIMAGE=y
 CONFIG_MEM_BANK="0x20000000"
 CONFIG_MEM_SIZE="0x20000000"
-CONFIG_LINUX_KERNEL_ARG_STRING="console=ttyS0,115200 mtdparts=atmel_nand:5M(Bootstrap),125M(system),-(userdata) ubi.mtd=1 ubi.mtd=2 rw root=ubi0:system rootfstype=ubifs init=/init androidboot.hardware=sama5d3x-ek androidboot.console=ttyS0"
+CONFIG_LINUX_KERNEL_ARG_STRING="console=ttyS0,115200 mtdparts=atmel_nand:5M(Bootstrap),125M(system),-(userdata) ubi.mtd=1 ubi.mtd=2 rw root=ubi0:system rootfstype=ubifs init=/init androidboot.console=ttyS0"
 CONFIG_IMG_ADDRESS="0x00200000"
 CONFIG_JUMP_ADDR="0x22000000"
 CONFIG_OF_LIBFDT=y

--- a/board/sama5d3xek/sama5d3xeksd_android_uimage_dt_defconfig
+++ b/board/sama5d3xek/sama5d3xeksd_android_uimage_dt_defconfig
@@ -102,7 +102,7 @@ CONFIG_LINUX_UIMAGE=y
 # CONFIG_LINUX_ZIMAGE is not set
 CONFIG_MEM_BANK="0x20000000"
 CONFIG_MEM_SIZE="0x20000000"
-CONFIG_LINUX_KERNEL_ARG_STRING="console=ttyS0,115200 root=/dev/mmcblk0p2 rw rootwait init=/init androidboot.hardware=sama5d3x-ek androidboot.console=ttyS0"
+CONFIG_LINUX_KERNEL_ARG_STRING="console=ttyS0,115200 root=/dev/mmcblk0p2 rw rootwait init=/init androidboot.console=ttyS0"
 CONFIG_JUMP_ADDR="0x22000000"
 CONFIG_OF_LIBFDT=y
 CONFIG_OF_ADDRESS="0x21000000"

--- a/board/sama5d3xek/sama5d3xeksd_android_zimage_dt_defconfig
+++ b/board/sama5d3xek/sama5d3xeksd_android_zimage_dt_defconfig
@@ -102,7 +102,7 @@ CONFIG_LOAD_ANDROID=y
 CONFIG_LINUX_ZIMAGE=y
 CONFIG_MEM_BANK="0x20000000"
 CONFIG_MEM_SIZE="0x20000000"
-CONFIG_LINUX_KERNEL_ARG_STRING="console=ttyS0,115200 root=/dev/mmcblk0p2 rw rootwait init=/init androidboot.hardware=sama5d3x-ek androidboot.console=ttyS0"
+CONFIG_LINUX_KERNEL_ARG_STRING="console=ttyS0,115200 root=/dev/mmcblk0p2 rw rootwait init=/init androidboot.console=ttyS0"
 CONFIG_JUMP_ADDR="0x22000000"
 CONFIG_OF_LIBFDT=y
 CONFIG_OF_ADDRESS="0x21000000"

--- a/driver/load_kernel.c
+++ b/driver/load_kernel.c
@@ -40,30 +40,11 @@
 
 #ifdef CONFIG_LOAD_ANDROID
 #ifdef CONFIG_SAMA5D3XEK
-#ifdef CONFIG_NANDFLASH
-static char *cmd_line_android_pda = "console=ttyS0,115200 " \
-		"mtdparts=atmel_nand:8M(bootstrap/kernel),125M(system)," \
-		"-(userdata) " \
-		"ubi.mtd=1 ubi.mtd=2 rw root=ubi0:system rootfstype=ubifs "\
-		"init=/init "\
-		"androidboot.hardware=sama5d3x-pda androidboot.console=ttyS0";
+static char *cmd_line_android_pda = LINUX_KERNEL_ARG_STRING \
+		" androidboot.hardware=sama5d3x-pda";
 
-static char *cmd_line_android = "console=ttyS0,115200 " \
-		"mtdparts=atmel_nand:8M(bootstrap/kernel),125M(system)," \
-		"-(userdata) " \
-		"ubi.mtd=1 ubi.mtd=2 rw root=ubi0:system rootfstype=ubifs " \
-		"init=/init " \
-		"androidboot.hardware=sama5d3x-ek androidboot.console=ttyS0";
-#endif
-#ifdef CONFIG_SDCARD
-static char *cmd_line_android_pda = "console=ttyS0,115200 " \
-		"root=/dev/mmcblk0p2 rw rootwait init=/init " \
-		"androidboot.hardware=sama5d3x-pda androidboot.console=ttyS0";
-
-static char *cmd_line_android = "console=ttyS0,115200 " \
-		"root=/dev/mmcblk0p2 rw rootwait init=/init " \
-		"androidboot.hardware=sama5d3x-ek androidboot.console=ttyS0";
-#endif
+static char *cmd_line_android = LINUX_KERNEL_ARG_STRING \
+		" androidboot.hardware=sama5d3x-ek";
 #endif /* #ifdef CONFIG_SAMA5D3XEK */
 #endif /* #ifdef CONFIG_LOAD_ANDROID */
 


### PR DESCRIPTION
For Android, the kernel bootarg config was hardcoded in the sources. This
patch changes this to take into account the config set during configuration
step.

Signed-off-by: Yann Soubeyrand ysoubeyrand@adeneo-embedded.com
