### PR TITLE
at91sam9g20ek: Force soft float build

### DIFF
--- a/board/at91sam9g20ek/board.mk
+++ b/board/at91sam9g20ek/board.mk
@@ -1,7 +1,7 @@
 CPPFLAGS += \
 	-DCONFIG_AT91SAM9G20EK \
-	-mcpu=arm926ej-s
+	-mcpu=arm926ej-s -mfloat-abi=soft
 
 ASFLAGS += \
 	-DCONFIG_AT91SAM9G20EK \
-	-mcpu=arm926ej-s
+	-mcpu=arm926ej-s -mfloat-abi=soft


### PR DESCRIPTION
Newer compilers default to the hard float ABI which this old board
doesn't support.  Explicitly say we want soft float (it would probably
be better to do this in some more generic place).

Signed-off-by: Mark Brown <broonie@kernel.org>