### PR TITLE
driver: flash, sd, of: cleanup image structure

### DIFF
--- a/driver/dataflash.c
+++ b/driver/dataflash.c
@@ -632,28 +632,27 @@ int load_dataflash(struct image_info *image)
 		goto err_exit;
 	}
 
-	if (image->of) {
-
+#ifdef CONFIG_OF_LIBFDT
 #if defined(CONFIG_LOAD_LINUX) || defined(CONFIG_LOAD_ANDROID)
-		length = update_image_length(df_desc,
-				image->of_offset, image->of_dest, DT_BLOB);
-		if (length == -1)
-			return -1;
+	length = update_image_length(df_desc,
+			image->of_offset, image->of_dest, DT_BLOB);
+	if (length == -1)
+		return -1;
 
-		image->of_length = length;
+	image->of_length = length;
 #endif
 
-		dbg_info("SF: dt blob: Copy %d bytes from %d to %d\n",
-			image->of_length, image->of_offset, image->of_dest);
+	dbg_info("SF: dt blob: Copy %d bytes from %d to %d\n",
+		image->of_length, image->of_offset, image->of_dest);
 
-		ret = dataflash_read_array(df_desc,
-			image->of_offset, image->of_length, image->of_dest);
-		if (ret) {
-			dbg_info("** SF: DT: Serial flash read error**\n");
-			ret = -1;
-			goto err_exit;
-		}
+	ret = dataflash_read_array(df_desc,
+		image->of_offset, image->of_length, image->of_dest);
+	if (ret) {
+		dbg_info("** SF: DT: Serial flash read error**\n");
+		ret = -1;
+		goto err_exit;
 	}
+#endif
 
 err_exit:
 	at91_spi_disable();

--- a/driver/load_kernel.c
+++ b/driver/load_kernel.c
@@ -51,7 +51,6 @@ static char *cmd_line_android = LINUX_KERNEL_ARG_STRING \
 #endif /* #ifdef CONFIG_LOAD_ANDROID */
 
 #ifdef CONFIG_OF_LIBFDT
-
 static int setup_dt_blob(void *blob)
 {
 	char *bootargs = LINUX_KERNEL_ARG_STRING;
@@ -92,15 +91,7 @@ static int setup_dt_blob(void *blob)
 
 	return 0;
 }
-
-static void setup_boot_params(void) {}
-
 #else
-static int setup_dt_blob(void *blob)
-{
-	return 0;
-}
-
 #define TAG_FLAG_NONE		0x00000000
 #define TAG_FLAG_CORE		0x54410001
 #define TAG_FLAG_MEM		0x54410002
@@ -366,19 +357,19 @@ int load_kernel(struct image_info *image)
 
 	kernel_entry = (void (*)(int, int, unsigned int))entry_point;
 
-	if (image->of) {
-		ret = setup_dt_blob((char *)image->of_dest);
-		if (ret)
-			return ret;
+#ifdef CONFIG_OF_LIBFDT
+	ret = setup_dt_blob((char *)image->of_dest);
+	if (ret)
+		return ret;
 
-		mach_type = 0xffffffff;
-		r2 = (unsigned int)image->of_dest;
-	} else {
-		setup_boot_params();
+	mach_type = 0xffffffff;
+	r2 = (unsigned int)image->of_dest;
+#else
+	setup_boot_params();
 
-		mach_type = MACH_TYPE;
-		r2 = (unsigned int)(MEM_BANK + 0x100);
-	}
+	mach_type = MACH_TYPE;
+	r2 = (unsigned int)(MEM_BANK + 0x100);
+#endif
 
 	dbg_info("\nStarting linux kernel ..., machid: %d\n\n",
 							mach_type);

--- a/driver/nandflash.c
+++ b/driver/nandflash.c
@@ -970,24 +970,24 @@ int load_nandflash(struct image_info *image)
 	if (ret)
 		return ret;
 
-	if (image->of) {
+#ifdef CONFIG_OF_LIBFDT
 #if defined(CONFIG_LOAD_LINUX) || defined(CONFIG_LOAD_ANDROID)
-		length = update_image_length(&nand,
-				image->of_offset, image->of_dest, DT_BLOB);
-		if (length == -1)
-			return -1;
+	length = update_image_length(&nand,
+			image->of_offset, image->of_dest, DT_BLOB);
+	if (length == -1)
+		return -1;
 
-		image->of_length = length;
+	image->of_length = length;
 #endif
 
-		dbg_info("NAND: dt blob: Copy %d bytes from %d to %d\n",
-			image->of_length, image->of_offset, image->of_dest);
+	dbg_info("NAND: dt blob: Copy %d bytes from %d to %d\n",
+		image->of_length, image->of_offset, image->of_dest);
 
-		ret = nand_loadimage(&nand, image->of_offset,
-					image->of_length, image->of_dest);
-		if (ret)
-			return ret;
-	}
+	ret = nand_loadimage(&nand, image->of_offset,
+				image->of_length, image->of_dest);
+	if (ret)
+		return ret;
+#endif
 
 	return 0;
  }

--- a/driver/sdcard.c
+++ b/driver/sdcard.c
@@ -100,31 +100,31 @@ int load_sdcard(struct image_info *image)
 		return -1;
 	}
 
-	if (image->of) {
-		if (sdcard_set_of_name)
-			sdcard_set_of_name(image->of_filename);
+#ifdef CONFIG_OF_LIBFDT
+	if (sdcard_set_of_name)
+		sdcard_set_of_name(image->of_filename);
 
-		/* mount fs */
-		fret = f_mount(0, &fs);
-		if (fret != FR_OK) {
-			dbg_info("*** FATFS: f_mount error **\n");
-			return -1;
-		}
-
-		dbg_info("SD/MMC: dt blob: Read file %s to %d\n",
-				image->of_filename, image->of_dest);
-
-		ret = sdcard_loadimage(image->of_filename, image->of_dest);
-		if (ret)
-			return ret;
-
-		/* umount fs */
-		fret = f_mount(0, NULL);
-		if (fret != FR_OK) {
-			dbg_info("*** FATFS: f_mount umount error **\n");
-			return -1;
-		}
+	/* mount fs */
+	fret = f_mount(0, &fs);
+	if (fret != FR_OK) {
+		dbg_info("*** FATFS: f_mount error **\n");
+		return -1;
 	}
+
+	dbg_info("SD/MMC: dt blob: Read file %s to %d\n",
+			image->of_filename, image->of_dest);
+
+	ret = sdcard_loadimage(image->of_filename, image->of_dest);
+	if (ret)
+		return ret;
+
+	/* umount fs */
+	fret = f_mount(0, NULL);
+	if (fret != FR_OK) {
+		dbg_info("*** FATFS: f_mount umount error **\n");
+		return -1;
+	}
+#endif
 
 	return 0;
 }

--- a/include/common.h
+++ b/include/common.h
@@ -47,21 +47,34 @@ enum {
 /* structure definition */
 struct image_info
 {
+#if defined(CONFIG_DATAFLASH) || defined(CONFIG_NANDFLASH)
 	unsigned int offset;
 	unsigned int length;
+#endif
+#ifdef CONFIG_SDCARD
 	char *filename;
+#endif
 	unsigned char *dest;
 
-	unsigned char of;
+#ifdef CONFIG_OF_LIBFDT
+#if defined(CONFIG_DATAFLASH) || defined(CONFIG_NANDFLASH)
 	unsigned int of_offset;
 	unsigned int of_length;
+#endif
+#ifdef CONFIG_SDCARD
 	char *of_filename;
+#endif
 	unsigned char *of_dest;
+#endif
 };
 
+#ifdef CONFIG_SDCARD
 extern void (*sdcard_set_of_name)(char *);
+#endif
 
+#if defined(CONFIG_LOAD_LINUX) || defined(CONFIG_LOAD_ANDROID)
 extern int kernel_size(unsigned char *addr);
+#endif
 
 static inline unsigned int swap_uint32(unsigned int data)
 {

--- a/main.c
+++ b/main.c
@@ -90,15 +90,20 @@ int main(void)
 	int ret;
 
 	char filename[FILENAME_BUF_LEN];
+
+#ifdef CONFIG_OF_LIBFDT
 	char of_filename[FILENAME_BUF_LEN];
+#endif
 
 	memset(&image, 0, sizeof(image));
 	memset(filename, 0, FILENAME_BUF_LEN);
+
+#ifdef CONFIG_OF_LIBFDT
 	memset(of_filename, 0, FILENAME_BUF_LEN);
+#endif
 
 	image.dest = (unsigned char *)JUMP_ADDR;
 #ifdef CONFIG_OF_LIBFDT
-	image.of = 1;
 	image.of_dest = (unsigned char *)OF_ADDRESS;
 #endif
 


### PR DESCRIPTION
Hi,

This patch cleans the image structure according to the .config.
- "offset", "length" are parts of image structure for CONFIG_xxxFLASH only,
- "of_offset", "of_length" are parts of image structure if both CONFIG_xxxFLASH  and CONFIG_OF_LIBFDT only,
- "of_filename" is part of image structure if both CONFIG_SDCARD and  CONFIG_OF_LIBFDT only,
- replace "of" boolean from image structure by CONFIG_OF_LIBFDT macro,
- declare sdcard_set_of_name function if CONFIG_SDCARD and
- declare kernel_size if CONFIG_LOAD_LINUX or CONFIG_LOAD_ANDROID.

I tested compilation against various boards at91xxx[nf,df,sd]_linux_image[_dt]_defconfig.