### PR TITLE
Added in delay after setting/getting on-die ecc feature. This is nece…

### DIFF
--- a/driver/nandflash.c
+++ b/driver/nandflash.c
@@ -229,6 +229,7 @@ static void nand_set_feature_on_die_ecc(unsigned char is_enable)
 	nand_command(CMD_SET_FEATURE);
 	nand_address(0x90);
 
+	udelay(100);
 	if (is_enable)
 		write_byte(0x08);
 	else
@@ -249,6 +250,7 @@ static unsigned char nand_get_feature_on_die_ecc(void)
 
 	nand_command(CMD_GET_FEATURE);
 	nand_address(0x90);
+	udelay(100);
 
 	for (i = 0; i < 4; i++)
 		buffer[i] = read_byte();


### PR DESCRIPTION
…ssary on some chips to perform these operations correctly.

The delay added was the difference between functional and non-functional on the mt29f1g08abadawp([http://www.micron.com/parts/nand-flash/mass-storage/mt29f1g08abadawp) (pdf: http://www.micron.com/~/media/documents/products/data-sheet/nand-flash/60-series/m68a_1gb_nand.pdf. This was on an at91sam9g45. 

The linked micron document specifies a 70us delay. I did brief research to find that a similar macronix chip wants a 1us delay. I suspect that the 100us value I input is larger than what either actually needs, but I think being on the safe side makes more sense than shaving 100us out of the boot time. 