### PR TITLE
sama5d3: Make slowclock bypass resistant to reset

### DIFF
--- a/driver/at91_slowclk.c
+++ b/driver/at91_slowclk.c
@@ -67,24 +67,6 @@ static void slowclk_disable_rc32(void)
 	reg &= ~AT91C_SLCKSEL_RCEN;
 	writel(reg, AT91C_BASE_SCKCR);
 }
-
-#if defined(CONFIG_SCLK_BYPASS)
-static void slowclk_bypass_osc32(void)
-{
-	unsigned int reg;
-
-	/*
-	 * Bypass the 32kHz oscillator by using an external clock
-	 */
-	reg = readl(AT91C_BASE_SCKCR);
-	reg |= AT91C_SLCKSEL_OSC32BYP;
-	writel(reg, AT91C_BASE_SCKCR);
-
-	reg = readl(AT91C_BASE_SCKCR);
-	reg &= ~AT91C_SLCKSEL_OSC32EN;
-	writel(reg, AT91C_BASE_SCKCR);
-}
-#endif /* #if defined(CONFIG_SCLK_BYPASS) */
 #endif /* #if !defined(SAMA5D4) && !defined(SAMA5D2) */
 
 static int slowclk_select_osc32(void)
@@ -118,11 +100,103 @@ int slowclk_switch_osc32(void)
 	slowclk_select_osc32();
 
 	slowclk_disable_rc32();
-
-#if defined(CONFIG_SCLK_BYPASS)
-	slowclk_bypass_osc32();
-#endif
 #endif
 
 	return 0;
 }
+
+
+#if defined(CONFIG_SCLK_BYPASS)
+/* Switch from 32768 Hz Crystal Oscillator to Internal 32 kHz RC Oscillator */
+static int slowclk_switch_rc32(void)
+{
+	unsigned int reg;
+
+	/* Enable the internal 32 kHz RC oscillator for low power by writing a 1 to the RCEN bit. */
+	reg = readl(AT91C_BASE_SCKCR);
+	reg |= AT91C_SLCKSEL_RCEN;
+	writel(reg, AT91C_BASE_SCKCR);
+
+	/* Wait internal 32 kHz RC startup time for clock stabilization (software loop). */
+	/* 500 us */
+	udelay(500);
+
+	/* Switch from 32768 Hz oscillator to internal RC by writing a 0 to the OSCSEL bit. */
+	reg = readl(AT91C_BASE_SCKCR);
+	reg &= ~AT91C_SLCKSEL_OSCSEL;
+	writel(reg, AT91C_BASE_SCKCR);
+
+	/* Wait 5 slow clock cycles for internal resynchronization. */
+	/* 5 slow clock cycles = ~153 us (5 / 32768) */
+	udelay(153);
+
+	/* Disable the 32768 Hz oscillator by writing a 0 to the OSC32EN bit. */
+	reg = readl(AT91C_BASE_SCKCR);
+	reg &= ~AT91C_SLCKSEL_OSC32EN;
+	writel(reg, AT91C_BASE_SCKCR);
+
+	return 0;
+}
+
+static int slowclk_osc32_bypass(void)
+{
+	unsigned int reg;
+
+	/* Bypass the 32kHz oscillator by using an external clock
+	 * Set OSC32BYP=1 and OSC32EN=0 atomically
+	 */
+	reg = readl(AT91C_BASE_SCKCR);
+	/* 32768 Hz oscillator is bypassed, accept an external slow clock on XIN32 */
+	reg |= AT91C_SLCKSEL_OSC32BYP;
+	/* 32768 Hz oscillator is disabled. */
+	reg &= ~AT91C_SLCKSEL_OSC32EN;
+	writel(reg, AT91C_BASE_SCKCR);
+
+	/*
+	 * Switching from internal 32kHz RC oscillator to 32768 Hz oscillator
+	 * by setting the bit OSCSEL to 1
+	 */
+	reg = readl(AT91C_BASE_SCKCR);
+	reg |= AT91C_SLCKSEL_OSCSEL;
+	writel(reg, AT91C_BASE_SCKCR);
+
+	/*
+	 * Waiting 5 slow clock cycles for internal resynchronization
+	 * 5 slow clock cycles = ~153 us (5 / 32768)
+	 */
+	udelay(153);
+
+	/*
+	 * Disable the 32kHz RC oscillator by setting the bit RCEN to 0
+	 */
+	reg = readl(AT91C_BASE_SCKCR);
+	reg &= ~AT91C_SLCKSEL_RCEN;
+	writel(reg, AT91C_BASE_SCKCR);
+
+	return 0;
+}
+
+/* Accept an external slow clock on XIN32 */
+int slowclk_switch_osc32_bypass(void)
+{
+	/*
+	 * On Atmel sama5d3x, if no quartz is connected to the 32768 Hz oscillator,
+	 * the SoC must not be resetted while OSC32BYP=1 and OSC32EN=1 and OSCSEL=1,
+	 * because it would cause the SoC to be blocked in reset.
+	 */
+
+	/* switch to internal RC32 ocsillator, in order to be sure to
+	 * have a reliable source for slow clock, at any moment during
+	 * the following steps
+	 */
+	slowclk_switch_rc32();
+
+	/* Enable OSC32, as it is needed for power supply of the osc by-pass cell
+	 */
+	slowclk_enable_osc32();
+
+	slowclk_osc32_bypass();
+
+	return 0;
+}
+#endif /* CONFIG_SCLK_BYPASS */

--- a/include/slowclk.h
+++ b/include/slowclk.h
@@ -30,5 +30,6 @@
 
 extern int slowclk_enable_osc32(void);
 extern int slowclk_switch_osc32(void);
+extern int slowclk_switch_osc32_bypass(void);
 
 #endif /* #ifndef __SLOWCLK_H__ */

--- a/main.c
+++ b/main.c
@@ -53,8 +53,10 @@ int main(void)
 #endif
 
 #if defined(CONFIG_SCLK)
+#if !defined(CONFIG_SCLK_BYPASS)
 #if !defined(CONFIG_SAMA5D4)
 	slowclk_enable_osc32();
+#endif
 #endif
 #endif
 
@@ -95,7 +97,11 @@ int main(void)
 	load_image_done(ret);
 
 #ifdef CONFIG_SCLK
+#ifdef CONFIG_SCLK_BYPASS
+	slowclk_switch_osc32_bypass();
+#else
 	slowclk_switch_osc32();
+#endif
 #endif
 
 #if defined(CONFIG_ENTER_NWD)


### PR DESCRIPTION
The original issue that lead to this modification
is that the sama5d3 gets blocked if reset while :
    OSC32BYP=1 and OSC32EN=1 and OSCSEL=1

This patch makes sure that this situation never occurs
at any moment.

----------------------------