### PR TITLE
Silence Python 3 errors: add paranthesis in print() calls

### DIFF
--- a/scripts/bitfieldsparser.py
+++ b/scripts/bitfieldsparser.py
@@ -40,7 +40,7 @@ def find_meaning(maps, bits):
 				if maps[bits["name"]] == array[1]:
 					return (int(name) << start) & mask
 
-			print "Error: not found"
+			print("Error: not found")
 		else:
 			# find the corresponding name, value in the maps, and shift as bit field.
 			return (maps[bits["name"]] << start) & mask
@@ -82,8 +82,8 @@ def parse_bitfield(fields, whole_word):
 					meaning_str = bits["meaning"][repr(value)][0]
 
 			if meaning_str == "":
-				print bits["name"], ':', value
+				print(bits["name"], ':', value)
 			else:
-				print bits["name"], ':', value, '->', meaning_str
+				print(bits["name"], ':', value, '->', meaning_str)
 		else:
-			print 'wrong type'
+			print('wrong type')

--- a/scripts/pmecc_head.py
+++ b/scripts/pmecc_head.py
@@ -65,7 +65,7 @@ def display_pmecc_header(file_name, val):
 	if data.has_key(name):
 		bitfieldsparser.parse_bitfield(data[name]["struct"], val)
 	else:
-		print 'Error: Cannot find the kay name: %s in the json file: %s' % (name, file_name)
+		print('Error: Cannot find the key name: %s in the json file: %s' % (name, file_name))
 	json_file.close()
 
 # Test code start here...


### PR DESCRIPTION
+ fix for typo "kay" -> "key"