### PR TITLE
load_kernel: add encrypted kernel support

### DIFF
--- a/Config.in.secure
+++ b/Config.in.secure
@@ -1,7 +1,7 @@
 config CONFIG_SECURE
 	bool "Secure Mode support"
 	default n
-	depends on CPU_HAS_AES && !CONFIG_LOAD_LINUX && !CONFIG_LOAD_ANDROID
+	depends on CPU_HAS_AES
 	select CONFIG_AES
 	help
 	  Decrypt and check the signature of the application file

--- a/driver/load_kernel.c
+++ b/driver/load_kernel.c
@@ -39,6 +39,7 @@
 #include "board_hw_info.h"
 #include "mon.h"
 #include "tz_utils.h"
+#include "secure.h"
 
 #include "debug.h"
 
@@ -361,6 +362,13 @@ int load_kernel(struct image_info *image)
 	ret = load_kernel_image(image);
 	if (ret)
 		return ret;
+
+#if defined(CONFIG_SECURE)
+	ret = secure_check(image->dest);
+	if (ret)
+		return ret;
+	image->dest += sizeof(at91_secure_header_t);
+#endif
 
 #ifdef CONFIG_SCLK
 	slowclk_switch_osc32();


### PR DESCRIPTION
Linux kernel load is implemented as a 'load_function'. But load_kernel()
normally does not return to its caller. So the existing image decryption call
in main() is not applicable to kernel images. Add a kernel decryption step in
load_kernel() to allow boot of encrypted kernel images.

Tested on SAMA5D2 Xplained board.

Fixes #43.

Signed-off-by: Baruch Siach baruch@tkos.co.il
