### PR TITLE
scripts: python: fix more python3 and python2 compatible issues

### DIFF
--- a/scripts/addpmecchead.py
+++ b/scripts/addpmecchead.py
@@ -17,7 +17,7 @@ elif sys.argv[3] == "sama5d4ek" or sys.argv[3] == "sama5d4_xplained":
 	pmecc_word = pmecc_head.gen_pmecc_header(4096, 224, 8, 512)
 elif sys.argv[3] == "at91sam9x5ek" or sys.argv[3] == "at91sam9n12ek":
 	pmecc_word = pmecc_head.gen_pmecc_header(2048, 64, 2, 512)
-elif sys.argv[3] == "core9g25" or sys.argv[3] == "core9g25":
+elif sys.argv[3] == "core9g25"
 	pmecc_word = pmecc_head.gen_pmecc_header(2048, 64, 2, 512)
 else:
 	sys.exit("Not support board!")

--- a/scripts/bitfieldsparser.py
+++ b/scripts/bitfieldsparser.py
@@ -77,8 +77,8 @@ def parse_bitfield(fields, whole_word):
 			# print 'mask: %x' % mask
 			value = (whole_word & mask) >> start
 			meaning_str = ""
-			if bits.has_key("meaning"):
-				if bits["meaning"].has_key(repr(value)):
+			if "meaning" in bits:
+				if repr(value) in bits["meaning"]:
 					meaning_str = bits["meaning"][repr(value)][0]
 
 			if meaning_str == "":

--- a/scripts/bitfieldsparser.py
+++ b/scripts/bitfieldsparser.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import struct, sys, json
 from pprint import pprint
 

--- a/scripts/pmecc_head.py
+++ b/scripts/pmecc_head.py
@@ -62,7 +62,7 @@ def display_pmecc_header(file_name, val):
 	json_file=open(file_name)
 	data = json.load(json_file)
 	#pprint(data["pmecc_header"]["usePmecc"])
-	if data.has_key(name):
+	if name in data:
 		bitfieldsparser.parse_bitfield(data[name]["struct"], val)
 	else:
 		print('Error: Cannot find the key name: %s in the json file: %s' % (name, file_name))
@@ -71,7 +71,7 @@ def display_pmecc_header(file_name, val):
 # Test code start here...
 # val = gen_pmecc_header(8192, 448, 8, 1024)
 #val = gen_pmecc_header(2048, 64, 4, 512)
-#print 'val = 0x%x' % val
-#print
+#print('val = 0x%x' % val)
+#print('')
 #val = 0xc1304805
 # display_pmecc_header("pmecc_head.json", val)


### PR DESCRIPTION
1. apply python 3 compatible rules in other python files.
2. make python 3 and python 2 print same output
3. misc remove duplicated condition check