### PR TITLE
AT91C_PIO_CFGR_DRVSTR typo fix

### DIFF
--- a/include/arch/at91_pio.h
+++ b/include/arch/at91_pio.h
@@ -126,9 +126,9 @@
 #define	AT91C_PIO_CFGR_OPD	(0x01 << 14)	/* Open-Drain */
 #define	AT91C_PIO_CFGR_SCHMITT	(0x01 << 15)	/* Schmitt Trigger*/
 #define	AT91C_PIO_CFGR_DRVSTR	(0x03 << 16)	/* Drive Strength*/
-#define		AT91C_PIO_CFGR_DRVSTR_HIGH	(0x00 << 16)
-#define		AT91C_PIO_CFGR_DRVSTR_MEDIUM	(0x01 << 16)
-#define		AT91C_PIO_CFGR_DRVSTR_LOW	(0x02 << 16)
+#define		AT91C_PIO_CFGR_DRVSTR_HIGH	(0x03 << 16)
+#define		AT91C_PIO_CFGR_DRVSTR_MEDIUM	(0x02 << 16)
+#define		AT91C_PIO_CFGR_DRVSTR_LOW	(0x01 << 16)
 #define	AT91C_PIO_CFGR_EVTSEL	(0x07 << 24)	/* Event Selection */
 #define		AT91C_PIO_CFGR_EVTSEL_FALLING	(0x00 << 24)
 #define		AT91C_PIO_CFGR_EVTSEL_RISING	(0x01 << 24)


### PR DESCRIPTION
I think there's a typo on AT91C_PIO_CFGR_DRVSTR, in the datasheet this register is 3=high, 2=medium, 1/0=low (on master it's the other way around).

Based on:
http://www.atmel.com/Images/Atmel-11267-32-bit-Cortex-A5-Microcontroller-SAMA5D2_Datasheet.pdf
and also a physical test I did on SAMA5D27 rev. b.