### PR TITLE
scripts: addpmecchead: loosen matching for sama5d3 boards

### DIFF
--- a/scripts/addpmecchead.py
+++ b/scripts/addpmecchead.py
@@ -11,7 +11,7 @@ fd.close()
 
 if sys.argv[3] == "sama5d2_ptc":
 	pmecc_word = pmecc_head.gen_pmecc_header(4096, 224, 8, 512)
-elif sys.argv[3] == "sama5d3xek" or sys.argv[3] == "sama5d3_xplained" or sys.argv[3] == "sama5d3x_cmp":
+elif sys.argv[3].startswith("sama5d3"):
 	pmecc_word = pmecc_head.gen_pmecc_header(2048, 64, 4, 512)
 elif sys.argv[3] == "sama5d4ek" or sys.argv[3] == "sama5d4_xplained":
 	pmecc_word = pmecc_head.gen_pmecc_header(4096, 224, 8, 512)


### PR DESCRIPTION
Custom boards needing pmecc fails to build with e.g.:

Not support board!
Makefile:329: recipe for target '/home/peda/src/tse-850/buildroot/output/build/at91bootstrap3-v3.8.6/binaries/sama5d3_linea-nandflashboot-uboot-3.8.6.bin.pmecc' failed

This is caused by the strict checking for board names in addpmecchead.py,
so loosen up the check to avoid contaminating the script with names of
contrib boards.

Signed-off-by: Peter Rosin <peda@axentia.se>