### PR TITLE
Bugfix: FDT parsing fails if node name length is even multiple of 4.

### DIFF
--- a/lib/fdt.c
+++ b/lib/fdt.c
@@ -183,6 +183,10 @@ static int of_get_token_nextoffset(void *blob,
 			cell++;
 			offset++;
 		} while (*cell != '\0');
+		/* the \0 is part of the node name, hence offset must be updated to the 
+		* position past the \0.
+		*/
+		++offset;
 	} else if (tag == OF_DT_TOKEN_PROP) {
 		/* the property value size */
 		plen = (unsigned int *)of_dt_struct_offset(blob, offset);


### PR DESCRIPTION
If the node name length excluding nul termination is an even multiple of 4, the FDT parsing fails since the offset of the next token is incorrect.