### PR TITLE
Allow users to override the devicetree blob filename as a menuconfig …

### DIFF
--- a/Config.in.kernel
+++ b/Config.in.kernel
@@ -91,6 +91,10 @@ config CONFIG_OF_LIBFDT
 	bool "Flattened Device Tree Support"
 	default y
 
+config CONFIG_OF_OVERRIDE_DTB_NAME
+	"string "Override Flattended Device Tree Blob filename"
+	depends on CONFIG_OF_LIBFDT && CONFIG_SDCARD
+
 config CONFIG_OF_OFFSET
 	string "The Offset of Flash Device Tree Blob "
 	depends on CONFIG_OF_LIBFDT && (CONFIG_DATAFLASH || CONFIG_FLASH || CONFIG_NANDFLASH)

--- a/driver/sdcard.c
+++ b/driver/sdcard.c
@@ -25,9 +25,12 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "autoconf.h"
 #include "common.h"
 #include "hardware.h"
 #include "board.h"
+
+#include "string.h"
 
 #include "ff.h"
 
@@ -151,6 +154,10 @@ int load_sdcard(struct image_info *image)
 
 #ifdef CONFIG_OF_LIBFDT
 	at91_board_set_dtb_name(image->of_filename);
+
+	if (strcmp(CONFIG_OF_OVERRIDE_DTB_NAME, "")) {
+                strcpy(image->of_filename, CONFIG_OF_OVERRIDE_DTB_NAME);
+        }
 
 	dbg_info("SD/MMC: dt blob: Read file %s to %x\n",
 			image->of_filename, image->of_dest);


### PR DESCRIPTION
…option

when loading Linux directly from an SDCard/eMMC boot media.