### PR TITLE
Add support for Macronix QSPI NOR flash.

### DIFF
--- a/driver/spi_flash/spi_nor_ids.c
+++ b/driver/spi_flash/spi_nor_ids.c
@@ -54,7 +54,19 @@
 	.page_size = 256,			\
 	.flags = SNOR_HAS_FSR | SNOR_SECT_4K | SNOR_NO_4BAIS
 
+#define MX25(_name, _jedec_id, _n_sectors)      \
+        .name = _name,                          \
+        ID5(_jedec_id, 0),                      \
+        .sector_size = 65536U,                  \
+        .n_sectors = (_n_sectors),              \
+        .page_size = 256,                       \
+        .flags = SNOR_SECT_4K | SNOR_NO_4BAIS
+
+
 const struct spi_nor_info spi_nor_ids[] = {
+	/* Macronix */
+	{ MX25("mx25l25635f", 0xc22019,  512), },
+
 	/* Micron */
 	{ N25Q("n25q032ax1", 0x20bb16,   64), },
 	{ N25Q("n25q032ax3", 0x20ba16,   64), },


### PR DESCRIPTION
MX25L25635F added to ID table.

Tested with SAMA5D2 SOM on custom board

Signed-off-by: Matt Wood <mattwood2000@gmail.com>