### PR TITLE
Add -fno-pie to CPPFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ NOSTDINC_FLAGS=-nostdinc -isystem $(shell $(CC) -print-file-name=include)
 
 CPPFLAGS=$(NOSTDINC_FLAGS) -ffunction-sections -g -Os -Wall \
 	-mno-unaligned-access \
-	-fno-stack-protector -fno-common -fno-builtin -fno-jump-tables \
+	-fno-stack-protector -fno-common -fno-builtin -fno-jump-tables -fno-pie \
 	-I$(INCL) -Icontrib/include -Iinclude -Ifs/include \
 	-I$(TOPDIR)/config/at91bootstrap-config \
 	-DAT91BOOTSTRAP_VERSION=\"$(VERSION)$(REV)$(SCMINFO)\" -DCOMPILE_TIME="\"$(DATE)\""


### PR DESCRIPTION
If gcc that is used to build at91bootstrap binary was configured with
'--enable-default-pie' option, resulting at91bootstrap binary will
compile on host but silently fail on target, so add '-fno-pie' option
to at91bootstrap CPPFLAGS to avoid this issue.

Signed-off-by: Niko Mauno <niko.mauno@vaisala.com>