### PR TITLE
Fix recursive make call consistency in config-clean.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ distrib: mrproper
 
 config-clean:
 	@echo "  CLEAN        "configuration files!
-	$(Q)make -C config distclean
+	$(Q)$(MAKE) -C config distclean
 	$(Q)rm -fr config/at91bootstrap-config
 	$(Q)rm -f  config/.depend
 


### PR DESCRIPTION
Every invokation of recursive make in Makefile uses $(MAKE)
except for the one in config-clean.  In BSD operating systems,
the default Make utility is POSIX Make, not GNU Make.  The
GNU version is in the ports tree and is named gmake.  By
making this replacement, at91bootstrap compiles cleanly in
OpenBSD.

Signed-off-by: Gregory P. Czerniak <greg@czerniak.info>