### PR TITLE
build: Consider SOURCE_DATE_EPOCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,13 @@ endif
 
 BINDIR:=$(TOPDIR)/binaries
 
-DATE := $(shell date)
+# see https://reproducible-builds.org/docs/source-date-epoch/#makefile
+DATE_FMT = %Y-%m-%d
+ifdef SOURCE_DATE_EPOCH
+	DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)"  2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u "+$(DATE_FMT)")
+else
+	DATE := $(shell date)
+endif
 VERSION := 3.8.12
 REVISION :=
 SCMINFO := $(shell ($(TOPDIR)/host-utilities/setlocalversion $(TOPDIR)))


### PR DESCRIPTION
The build is not reproducible, because the build date is compiled in.
Avoid that, if env variable SOURCE_DATE_EPOCH is set (like some build
environments do).

The approach used here is directly taken from the reproducible builds
project. See:
https://reproducible-builds.org/docs/source-date-epoch/#makefile

Console output before:

    AT91Bootstrap 3.8.12 (Mon Feb  4 13:02:06 CET 2019)

Console output after:

    AT91Bootstrap 3.8.12 (2019-01-01)

If SOURCE_DATE_EPOCH is not set, the old behaviour is kept.

Signed-off-by: Alexander Dahl <post@lespocky.de>