### PR TITLE
board: sama5d27_som1_ek: Fix LED switch on

### DIFF
--- a/board/sama5d27_som1_ek/sama5d27_som1_ek.c
+++ b/board/sama5d27_som1_ek/sama5d27_som1_ek.c
@@ -319,9 +319,21 @@ void at91_init_can_message_ram(void)
 	       (AT91C_BASE_SFR + SFR_CAN));
 }
 
-static void at91_red_led_on(void)
+static void led_hw_init(void)
 {
-	pio_set_gpio_output(AT91C_PIN_PA(27), 0);
+	const struct pio_desc led_pins[] = {
+		{"LED_RED", CONFIG_SYS_LED_RED_PIN, 0, PIO_PULLUP, PIO_OUTPUT},
+		{"LED_GREEN", CONFIG_SYS_LED_GREEN_PIN, 0, PIO_PULLUP, PIO_OUTPUT},
+		{"LED_BLUE", CONFIG_SYS_LED_BLUE_PIN, 0, PIO_PULLUP, PIO_OUTPUT},
+		{(char *)0, 0, 0, PIO_DEFAULT, PIO_PERIPH_A}
+	};
+
+	pio_configure(led_pins);
+}
+
+static void at91_led_on(void)
+{
+	pio_set_gpio_output(CONFIG_SYS_LED_GREEN_PIN, 1);
 }
 
 #ifdef CONFIG_HW_INIT
@@ -329,7 +341,9 @@ void hw_init(void)
 {
 	at91_disable_wdt();
 
-	at91_red_led_on();
+	led_hw_init();
+
+	at91_led_on();
 
 	pmc_cfg_plla(PLLA_SETTINGS);
 

--- a/board/sama5d27_som1_ek/sama5d27_som1_ek.h
+++ b/board/sama5d27_som1_ek/sama5d27_som1_ek.h
@@ -101,4 +101,11 @@
 #define CONFIG_SYS_ID_SDHC	AT91C_ID_SDMMC1
 #endif
 
+/*
+ * LEDs
+ */
+#define CONFIG_SYS_LED_RED_PIN      AT91C_PIN_PA(10)
+#define CONFIG_SYS_LED_GREEN_PIN    AT91C_PIN_PB(1)
+#define CONFIG_SYS_LED_BLUE_PIN     AT91C_PIN_PA(31)
+
 #endif


### PR DESCRIPTION
The code did set the output of pin PA27 to low.  According to SAMA5D27
SOM1 Kit1 User's Guide that is used as enable signal for an USB power
switch.  The red LED is actually connected active high to PA10 through a
MOSFET.  (Maybe that changed from an early prototype?)

If you power up the board without any bootloader, it goes to SAM-BA mode
and the red LED is on.  Switching that red LED on again in bootstrap
would give no benefit.  To see if the bootstrap was actually loaded,
this is changed to switch the green LED on now.

Fixes: a4f6043cfbb04b04d29abddb77658fbf6e66bfa0
Signed-off-by: Alexander Dahl <ada@thorsis.com>