### PR TITLE
Makefile: restore target name when CONFIG_FATFS is not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,31 +176,31 @@ BLOB:=
 endif
 
 ifeq ($(CONFIG_LOAD_LINUX), y)
-TARGET_NAME:=linux-$(subst I,i,$(IMAGE_NAME))
+TARGET_NAME:=linux-$(or $(subst I,i,$(IMAGE_NAME)),image)
 endif
 
 ifeq ($(CONFIG_LOAD_ANDROID), y)
-TARGET_NAME:=android-$(subst I,i,$(IMAGE_NAME))
+TARGET_NAME:=android-$(or $(subst I,i,$(IMAGE_NAME)),image)
 endif
 
 ifeq ($(CONFIG_LOAD_UBOOT), y)
-TARGET_NAME:=$(subst -,,$(basename $(IMAGE_NAME)))
+TARGET_NAME:=$(or $(subst -,,$(basename $(IMAGE_NAME))),uboot)
 endif
 
 ifeq ($(CONFIG_LOAD_64KB), y)
-TARGET_NAME:=$(basename $(IMAGE_NAME))
+TARGET_NAME:=$(or $(basename $(IMAGE_NAME)),softpack)
 endif
 
 ifeq ($(CONFIG_LOAD_1MB), y)
-TARGET_NAME:=$(basename $(IMAGE_NAME))
+TARGET_NAME:=$(or $(basename $(IMAGE_NAME)),softpack)
 endif
 
 ifeq ($(CONFIG_LOAD_4MB), y)
-TARGET_NAME:=$(basename $(IMAGE_NAME))
+TARGET_NAME:=$(or $(basename $(IMAGE_NAME)),softpack)
 endif
 
 ifeq ($(CONFIG_LOAD_NONE), y)
-TARGET_NAME:=$(basename $(IMAGE_NAME))
+TARGET_NAME:=$(or $(basename $(IMAGE_NAME)),none)
 endif
 
 BOOT_NAME=$(BOARDNAME)-$(PROJECT)$(CARD_SUFFIX)boot-$(TARGET_NAME)$(BLOB)-$(VERSION)$(REV)


### PR DESCRIPTION
Commit e60cccc4637d ("Config.in: add the dependency of
CONFIG_IMAGE_NAME") made CONFIG_IMAGE_NAME a dependency of CONFIG_FATFS.
This has the unwanted side effect of losing the target image component
of the built binary filenames when CONFIG_FATFS is not defined. For
example, what would previously have been built as
"sama5d3xek-nandflashboot-uboot-3.8.12.bin" becomes
"sama5d3xek-nandflashboot--3.8.12.bin" (note the two hyphens).

This commit fixes the problem by substituting default image names when
CONFIG_IMAGE_NAME is undefined.