### PR TITLE
sama5d27_som1_ek: fix over-consumption erratum check

### DIFF
--- a/board/sama5d27_som1_ek/sama5d27_som1_ek.c
+++ b/board/sama5d27_som1_ek/sama5d27_som1_ek.c
@@ -557,7 +557,7 @@ void at91_sdhc_hw_init(void)
 	reg = readl(AT91C_BASE_SDHC0 + SDMMC_CALCR);
 	pmc_disable_periph_clock(AT91C_ID_SDMMC0);
 
-	if (reg | SDMMC_CALCR_ALWYSON)
+	if (reg & SDMMC_CALCR_ALWYSON)
 		dbg_info("SDHC: fix in place for SAMA5D2 SoM VDDSDMMC over-consumption errata\n");
 
 	/* Deal with usual SD/MCC peripheral init sequence */


### PR DESCRIPTION
at91_sdhc_hw_init checks whether the over-consumption erratum fix is in
place by evaluating the SDMMC_CALCR register. However, the check is a
bitwise OR, which results in the condition always being true. Use a
bitwise AND to check if the ALWYSON bit is set.