### PR TITLE
lib/fdt: Constify input char* args

### DIFF
--- a/lib/fdt.c
+++ b/lib/fdt.c
@@ -250,7 +250,7 @@ static int of_get_nextnode_offset(void *blob,
 	return 0;
 }
 
-static int of_get_node_offset(void *blob, char *name, int *offset)
+static int of_get_node_offset(void *blob, const char *name, int *offset)
 {
 	int start_offset = 0;
 	int nodeoffset = 0;
@@ -369,7 +369,7 @@ static int of_get_next_property_offset(void *blob,
 
 static int of_get_property_offset_by_name(void *blob,
 					unsigned int nodeoffset,
-					char *name,
+					const char *name,
 					int *offset)
 {
 	unsigned int nameoffset;
@@ -521,7 +521,7 @@ static int of_update_property_value(void *blob,
 
 static int of_set_property(void *blob,
 				int nodeoffset,
-				char *property_name,
+				const char *property_name,
 				void *value,
 				int valuelen)
 {


### PR DESCRIPTION
The functions are called with constant character literals aka `const char *`:
ret = of_get_node_offset(blob, "chosen", &nodeoffset);
ret = of_get_node_offset(blob, "memory", &nodeoffset);
ret = of_set_property(blob, nodeoffset, "bootargs", value, valuelen);
ret = of_set_property(blob, nodeoffset, "device_type", "memory", sizeof("memory"));
ret = of_set_property(blob, nodeoffset, "reg", data, valuelen);

Signed-off-by: Kristof Havasi <kristof.havasi@gmail.com>