### PR TITLE
Add OP-TEE loading support to at91bootstrap v4.x

### DIFF
--- a/Config.in.optee
+++ b/Config.in.optee
@@ -1,0 +1,39 @@
+# Copyright (C) 2021 Microchip Technology Inc. and its subsidiaries
+#
+# SPDX-License-Identifier: MIT
+
+config LOAD_OPTEE
+	bool "Install and start OP-TEE Trusted OS"
+	depends on SDCARD
+	help
+	  When enabled, OP-TEE will be loaded from NVM and installed in external
+	  RAM or DRAM.
+	  OP-TEE will run in Secure World and its memory zone will be secured. A
+	  monitor will be installed and handled by OP-TEE to handle NW/SW
+	  switches as well as SMCs. The selected component (Linux/U-Boot) will
+	  be loaded in RAM as well but will run in Normal World after returning
+	  from OP-TEE.
+
+menu "OP-TEE Image Loading Info"
+	depends on LOAD_OPTEE
+
+config OPTEE_IMAGE_NAME
+	string "OP-TEE Image Name"
+	default "tee.bin"
+
+config OPTEE_IMG_SIZE
+	hex "OP-TEE Maximum Image Size"
+	default	"0x1000000"
+	help
+	  When using SDCard, this is the maximum size that will be allowed for
+	  OP-TEE binary.
+
+config OPTEE_JUMP_ADDR
+	hex "External Ram Address For OP-TEE Image"
+	default "0x20000000"
+	help
+	  This address is the entry point to which the bootstrap will pass
+	  control to OP-TEE. OP-TEE must be compiled to run at this address. If
+	  not, an error will be displayed and OP-TEE won't be loaded.
+
+endmenu

--- a/Kconfig
+++ b/Kconfig
@@ -137,6 +137,7 @@ config LOAD_UBOOT
 	  such as U-Boot, placed in the last MByte of SDRAM.
 
 config LOAD_LINUX
+	depends on !LOAD_OPTEE
 	select LINUX_IMAGE
 	bool "Linux Kernel"
 	---help---
@@ -144,6 +145,7 @@ config LOAD_LINUX
 	  No further bootloader required.
 
 config LOAD_ANDROID
+	depends on !LOAD_OPTEE
 	select LINUX_IMAGE
 	bool "Android"
 	---help---
@@ -151,18 +153,21 @@ config LOAD_ANDROID
 	  No further bootloader required.
 
 config LOAD_1MB
+	depends on !LOAD_OPTEE
 	bool "Load 1 MB into start of SDRAM"
 	---help---
 	  Use this mode to load an embedded application
 	  which can have a size of up to 1 MByte
 
 config LOAD_4MB
+	depends on !LOAD_OPTEE
 	bool "Load 4 MB into start of SDRAM"
 	---help---
 	  Use this mode to load an embedded application
 	  which can have a size of up to 4 MByte
 
 config LOAD_64KB
+	depends on !LOAD_OPTEE
 	bool "Load 64 kB into the start of SDRAM"
 	---help---
 	  Use this mode to load an embedded application
@@ -225,7 +230,10 @@ config MATRIX
 	  This interface let you to configure the MATRIX0(H64MX) and
 	  MATRIX1(H32MX) slave security  and to select the APB slave security startup.
 
+source "Config.in.optee"
+
 config ENTER_NWD
+	depends on !LOAD_OPTEE
 	select MATRIX
 	bool "Enable Enter the Normal World before Jumping"
 	default n
@@ -234,6 +242,7 @@ config ENTER_NWD
 	  to the Non-Secure World before the jumping.
 
 config REDIRECT_ALL_INTS_AIC
+	depends on !LOAD_OPTEE
 	bool "Redirect All Peripherals Interrupts to AIC"
 	default y
 	help

--- a/Kconfig
+++ b/Kconfig
@@ -137,7 +137,6 @@ config LOAD_UBOOT
 	  such as U-Boot, placed in the last MByte of SDRAM.
 
 config LOAD_LINUX
-	depends on !LOAD_OPTEE
 	select LINUX_IMAGE
 	bool "Linux Kernel"
 	---help---

--- a/driver/driver.mk
+++ b/driver/driver.mk
@@ -79,6 +79,9 @@ COBJS-$(CONFIG_ENTER_NWD)	+= $(DRIVERS_SRC)/monitor/mon_init.o
 COBJS-$(CONFIG_ENTER_NWD)	+= $(DRIVERS_SRC)/monitor/mon_switch.o
 COBJS-$(CONFIG_ENTER_NWD)	+= $(DRIVERS_SRC)/monitor/mon_vectors.o
 
+COBJS-$(CONFIG_LOAD_OPTEE)	+= $(DRIVERS_SRC)/optee/optee_switch.o
+COBJS-$(CONFIG_LOAD_OPTEE)	+= $(DRIVERS_SRC)/optee/optee.o
+
 COBJS-$(CONFIG_PM)	+= $(DRIVERS_SRC)/pm.o
 COBJS-$(CONFIG_TWI)	+= $(DRIVERS_SRC)/at91_twi.o
 COBJS-$(CONFIG_ACT8865)	+= $(DRIVERS_SRC)/act8865.o

--- a/driver/optee/optee.c
+++ b/driver/optee/optee.c
@@ -1,0 +1,146 @@
+// Copyright (C) 2021 Microchip Technology Inc. and its subsidiaries
+//
+// SPDX-License-Identifier: MIT
+
+#include "common.h"
+#include "debug.h"
+#include "optee.h"
+#include "types.h"
+#include "string.h"
+
+#define OPTEE_MAGIC             0x4554504f
+#define OPTEE_VERSION           1
+#define OPTEE_ARCH_ARM32        0
+#define OPTEE_ARCH_ARM64        1
+
+struct nw_params {
+	unsigned int r1;
+	unsigned int r2;
+	void *nw_addr;
+} __attribute__((packed));
+
+static struct nw_params nw_params;
+
+struct optee_header {
+        u32 magic;
+        u8 version;
+        u8 arch;
+        u16 flags;
+        u32 init_size;
+        u32 init_load_addr_hi;
+        u32 init_load_addr_lo;
+        u32 init_mem_usage;
+        u32 paged_size;
+} __attribute__((packed));
+
+/*
+ * Save r0, r1, r2 to be set when jumping to normal world at nw_addr.
+ */
+void optee_init_nw_params(void *nw_addr, unsigned int r0,
+ 			  unsigned int r1, unsigned int r2)
+{
+	/* r0 is set to 0 when returning to normal world by OP-TEE */
+	if (r0 != 0)
+		dbg_loud("r0 must be set to 0 !");
+
+	nw_params.r1 = r1;
+	nw_params.r2 = r2;
+	nw_params.nw_addr = nw_addr;
+}
+
+void optee_image_init(struct image_info *image)
+{
+	memset(image, 0, sizeof(*image));
+
+	image->dest = (unsigned char *) CONFIG_OPTEE_JUMP_ADDR;
+
+#ifdef CONFIG_SDCARD
+	image->filename = CONFIG_OPTEE_IMAGE_NAME;
+#endif
+
+}
+
+int optee_image_check(struct image_info *image, void **pagestore,
+		      unsigned long *optee_size)
+{
+	struct optee_header *hdr = (struct optee_header *) image->dest;
+
+	if ((u32) image->dest % 4) {
+		dbg_loud("Invalid OP-TEE image alignment\n");
+		return -1;
+	}
+
+	if (hdr->magic != OPTEE_MAGIC ||
+	    hdr->version != OPTEE_VERSION ||
+	    hdr->arch != OPTEE_ARCH_ARM32 ||
+	    hdr->init_load_addr_lo != CONFIG_OPTEE_JUMP_ADDR ||
+	    hdr->init_load_addr_hi != 0) {
+		dbg_loud("Invalid OP-TEE image\n");
+		return -1;
+	}
+
+	*optee_size = hdr->init_size + hdr->paged_size;
+
+	if (*optee_size > CONFIG_OPTEE_IMG_SIZE) {
+		dbg_loud("OP-TEE image size too big\n");
+		return -1;
+	}
+
+	*pagestore = (void *) (image->dest + *optee_size);
+
+	return 0;
+}
+
+#ifdef CONFIG_LOAD_SW
+static void optee_load_image(void **page_store)
+{
+	int ret;
+	unsigned long optee_size = 0;
+	struct image_info image = {0};
+	load_function load_func = get_image_load_func();
+
+	optee_image_init(&image);
+
+	ret = load_func(&image);
+	if (ret) {
+		dbg_loud("Failed to load OP-TEE\n");
+		while(1);
+	}
+
+	ret = optee_image_check(&image, page_store, &optee_size);
+	if (ret < 0)
+		while(1);
+
+	/*
+	 * Since OP-TEE is loaded by default at 0x20000000 which is the DDR
+	 * base, we can't copy it with the header offset. thus we load it at
+	 * the load address and then memmove it in the correct location.
+	 * OP-TEE is relatively small and the memmove overhead is really small.
+	 */
+	memmove(image.dest, image.dest + sizeof(struct optee_header),
+		optee_size);
+}
+#else
+static void optee_load_image(void **page_store) {}
+#endif
+
+void optee_start(void *pager, u32 r1, u32 dtb_addr, void *nw_addr);
+
+void optee_load(void)
+{
+	void *page_store = NULL;
+
+	optee_load_image(&page_store);
+
+	/*
+	 * If not overriden (by load_kernel for instance), set nw_addr to
+	 * JUMP_ADDR and r2 to the normal world device tree
+	 */
+	if (nw_params.nw_addr == NULL)
+		nw_params.nw_addr = (void *)JUMP_ADDR;
+
+	dbg_info("Starting OP-TEE, Run at %x, Non-secure entry at %x\n",
+		 CONFIG_OPTEE_JUMP_ADDR, nw_params.nw_addr);
+
+	optee_start(page_store, nw_params.r1, nw_params.r2, nw_params.nw_addr);
+}

--- a/driver/optee/optee_switch.S
+++ b/driver/optee/optee_switch.S
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2021 Microchip Technology Inc. and its subsidiaries
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hardware.h>
+
+	.text
+	.align
+	.thumb_func
+/*
+ * OP-TEE expect the following boot arguments
+ * r0: pagestore
+ * r1: (ARMv7 standard bootarg #1)
+ * r2: device tree address, (ARMv7 standard bootarg #2)
+ * r3: return address
+ */
+.global optee_start
+optee_start:
+	mov	lr, r3
+	ldr	r4, =CONFIG_OPTEE_JUMP_ADDR
+	bx	r4
+	b	.
+
+.end

--- a/include/optee.h
+++ b/include/optee.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2021 Microchip Technology Inc. and its subsidiaries
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef __OPTEE_H__
+#define __OPTEE_H__
+
+void optee_load(void);
+void optee_init_nw_params(void *nw_addr, unsigned int r0,
+ 			  unsigned int r1, unsigned int r2);
+
+#endif

--- a/main.c
+++ b/main.c
@@ -13,6 +13,8 @@
 #include "mcp16502.h"
 #include "backup.h"
 #include "secure.h"
+#include "autoconf.h"
+#include "optee.h"
 #include "sfr_aicredir.h"
 
 #ifdef CONFIG_HW_DISPLAY_BANNER
@@ -113,6 +115,11 @@ int main(void)
 #else
 	slowclk_switch_osc32();
 #endif
+#endif
+
+#if defined(CONFIG_LOAD_OPTEE)
+	/* Will never return since we will jump to OP-TEE in secure mode */
+	optee_load();
 #endif
 
 #if defined(CONFIG_ENTER_NWD)


### PR DESCRIPTION
This pull-request add the possibility to load optee binary from non volatile memory and boot it before booting the second level bootloader. Currently, U-Boot memory range needs to be modified to only use 0x20000000 -> 0x30000000 range where OP-TEE memory starts:

```
-#define CONFIG_SYS_SDRAM_SIZE          0x20000000
+#define CONFIG_SYS_SDRAM_SIZE          0x10000000
```

Once done, OP-TEE can start U-Boot:

```
AT91Bootstrap 4.0.0-rc3-00002-g5cefac2 (2021-06-08 14:29:12)

EEPROM: Loading AT24xx information ...
EEPROM: BoardName | [Revid] | VendorName
  #0  SAMA5D2-XULT [AB1]      ATMEL-RF0
EEPROM: BoardDate | Year | Week
EEPROM:             2016    27

EEPROM: Board sn: 0xd300000 revision: 0x400000

SD/MMC: Image: Read file u-boot.bin to 0x26f00000
MMC: ADMA supported
SD: Card Capacity: High or Extended
SD: Specification Version 3.0X
SD/MMC: Done to load image
SD/MMC: Image: Read file optee.bin to 0x2fffffe4
OP-TEE hdr info:
      magic=0x4554504f
      version=0x1
      arch=0x0
      flags=0x0
      load_addr=0x30000000
      init_size=0x768a8
Starting OP-TEE, Run at 0x30000000

...

I/TC: Non-secure external DT found
I/TC: Embedded DTB found
I/TC: atmel_uart: device parameters ignored (115200n8)
I/TC: Switching console to device: /ahb/apb/serial@f8020000
I/TC: OP-TEE version: 3.13.0-71-g716ecb6b-dev (gcc version 10.2.1 20210110 (Debian 10.2.1-6)) #15 Mon Jun  7 14:20:12 UTC 2021 arm
I/TC: Primary CPU initializing
I/TC: Primary CPU switching to normal world boot

<debug_uart>


U-Boot 2021.07-rc3-00060-g89be8e31cc-dirty (Jun 03 2021 - 14:38:13 +0200)

CPU: Unknown CPU type
Crystal frequency:       12 MHz
CPU clock        :      498 MHz
Master clock     :      166 MHz
DRAM:  256 MiB
MMC:   sdio-host@a0000000: 0, sdio-host@b0000000: 1
Loading Environment from SPIFlash... SF: Detected at25df321a with page size 256 Bytes, erase size 4 KiB, total 4 MiB
*** Warning - bad CRC, using default environment

...

Starting kernel ...

Booting Linux on physical CPU 0x0
Linux version 4.19.78-linux4sam-6.2 (oe-user@oe-host) (gcc version 8.3.0 (GCC)) #1 Thu Oct 24 23:16:08 UTC 2019
```

Supported header for OP-TEE binary is only version 1 (same as U-Boot).
The current implementation let at91bootstrap load both OP-TEE and U-Boot and pass normal world boot informations to OP-TEE via registers.
