### PR TITLE
Makefile: Remove -nostartfiles from LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ endif
 #    --cref:    add cross reference to map file
 #  -lc 	   : 	tells the linker to tie in newlib
 #  -lgcc   : 	tells the linker to tie in newlib
-LDFLAGS=-nostartfiles -Map=$(BINDIR)/$(BOOT_NAME).map --cref -static
+LDFLAGS=-Map=$(BINDIR)/$(BOOT_NAME).map --cref -static
 LDFLAGS+=-T $(link_script) $(GC_SECTIONS) -Ttext $(LINK_ADDR)
 
 ifneq ($(DATA_SECTION_ADDR),)


### PR DESCRIPTION
Binutils linker ld does not support the flag -nostartfiles. This is interpreted as "-n -o startfiles" which fortunately has no impact on the build process. Removing -nostartfiles has no impact on the build.

Binutils 2.36 and later ld has improved flag parsing and throws an error if -nostartfiles is passed as an argument. Removing the flag fixes the problem.
Details on the Binutils ML: https://sourceware.org/pipermail/binutils/2021-June/116826.html

resolves linux4sam/at91bootstrap#127