### PR TITLE
device: remove board_override_cmd_line() from sama5d3

### DIFF
--- a/device/sama5d3/sama5d3.c
+++ b/device/sama5d3/sama5d3.c
@@ -301,20 +301,6 @@ void hw_init(void)
 #endif
 }
 
-char *board_override_cmd_line(void)
-{
-	char *cmdline = NULL;
-
-#if defined(CONFIG_LOAD_ANDROID)
-	/* Setup Android command-line */
-	if (get_dm_sn() == BOARD_ID_PDA_DM)
-		cmdline = CMDLINE " androidboot.hardware=sama5d3x-pda";
-	else
-		cmdline = CMDLINE " androidboot.hardware=sama5d3x-ek";
-#endif
-	return cmdline;
-}
-
 #ifdef CONFIG_DATAFLASH
 void at91_spi0_hw_init(void)
 {


### PR DESCRIPTION
This pull request addresses issue #126.

According to Nicolas Ferre, the Android-specific code in this function is not needed anymore. Then, this version of the function can be removed, and we can instead rely on the [default, weak implementation][weak] defined in driver/load_kernel.c.

Incidentally, this fixes a bug, as this `board_override_cmd_line()` would return `NULL` unless `CONFIG_LOAD_ANDROID` was set.

Combined with [Tony Han's patch to Config.in.kernel][patch], this makes the [Acqua board][acqua] bootable by AT91Boostrap&nbsp;4.

[weak]: ../blob/v4.0.0-rc3/driver/load_kernel.c#L372-L375
[patch]: ../issues/126#issuecomment-856469395
[acqua]: https://www.acmesystems.it/acqua