### PR TITLE
driver: ddramc: LPDDR1 Enable

### DIFF
--- a/device/sam9x60/sam9x60.c
+++ b/device/sam9x60/sam9x60.c
@@ -324,7 +324,7 @@ void hw_init(void)
 	 * We need to also enable AT91C_EBI_NFD0_ON_D16 . Otherwise the DDR will
 	 * not work if NAND lines have been previously used by RomCode
 	 */
-#ifdef CONFIG_DDR2
+#ifdef CONFIG_DDRC
 	reg |= (AT91C_EBI_CS1A | AT91C_EBI_DDR_MP_EN | AT91C_EBI_NFD0_ON_D16);
 	writel(reg, (AT91C_BASE_SFR + SFR_DDRCFG));
 	/* Initialize DDRAM Controller */

--- a/driver/ddramc.c
+++ b/driver/ddramc.c
@@ -623,7 +623,9 @@ void ddram_init(void)
 	 * the DDR_DQ and DDR_DQS input buffers to always on by setting
 	 * the FDQIEN and FDQSIEN bits in the SFR_DDRCFG register.
 	 */
+#if defined(CONFIG_SAMA5D2) || defined(CONFIG_SAMA5D4)
 	pmc_enable_periph_clock(AT91C_ID_SFR, PMC_PERIPH_CLK_DIVIDER_NA);
+#endif
 	reg = readl(AT91C_BASE_SFR + SFR_DDRCFG);
 	reg |= AT91C_DDRCFG_FDQIEN;
 	reg |= AT91C_DDRCFG_FDQSIEN;


### PR DESCRIPTION
Enabling LPDDR1 on SAM9x60 causes a compile error as the AT91C_ID_SFR
register is defined only for SAMA5D2 and SAMA5D4.