### PR TITLE
Allow Thumb mode tot be selected for SAMA5DX boards

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -208,7 +208,7 @@ source "device/Config.in.mach"
 source "Config.in.secure"
 
 config THUMB
-	depends on !(SAMA5D3X || SAMA5D4)
+	depends on !SAMA5D4
 	bool "Build in thumb mode"
 	help
 	  Build code in thumb mode


### PR DESCRIPTION
Close #152 

We have been using thumb mode on our SAMA5D3 based board for over 5 years with success and the generated binaries have been always smaller in thumb mode than in ARM mode.

So allow the `CONFIG_THUMB` menu item for the `SAMA5D3` boards