### PR TITLE
crt0_gnu.S: always pass along r4 to next stage

### DIFF
--- a/crt0_gnu.S
+++ b/crt0_gnu.S
@@ -7,6 +7,12 @@
 #include <hardware.h>
 #include <mon_macros.h>
 
+#if defined(CONFIG_ENTER_NWD)
+#define	STACK_TOP		SVC_STACK_BASE
+#else
+#define	STACK_TOP		TOP_OF_MEMORY
+#endif
+
 .section start
 	.text
 
@@ -68,12 +74,9 @@ reset_vector:
 
 /* Init the stack */
 _init_stack:
-
-#if defined(CONFIG_ENTER_NWD)
-	ldr	sp,=SVC_STACK_BASE
-#else
-	ldr     sp,=TOP_OF_MEMORY
-#endif
+	ldr	sp,=STACK_TOP
+	/* Save BootROM supplied boot source information to stack */
+	push	{r4}
 
 #ifdef CONFIG_FLASH
 /*
@@ -156,10 +159,8 @@ _branch_main:
 
 /* Branch to the application at the end of the bootstrap init */
 _go:
-#ifdef BACKUP_REGISTER_BOOT_MODE_R4
-	ldr	r1, =BACKUP_REGISTER_BOOT_MODE_R4
+	ldr	r1, =(STACK_TOP - 4)
 	ldr	r4, [r1]
-#endif
 	ldr 	r1, =MACH_TYPE
 	mov     lr, pc
 


### PR DESCRIPTION
At least on the SAMA5D2, D3 and D4, the BootROM encodes information about
the boot source into the r4 register. AT91Bootstrap discards this
information on all SoCs except for the SAMA5D3. Fix this by storing r4
at a universally applicable location (first word of stack) and passing
it along to the next boot stage, so it can decide how to act on this.

In order to keep backwards compatibility with next stage boot firmware
that looks at the GPBR instead of r4, we keep the store to GPBR
unchanged and replace only the load with aforementioned stack top.

Acked-by: Nicolas Ferre <nicolas.ferre@microchip.com>                      
Signed-off-by: Ahmad Fatoum <a.fatoum@pengutronix.de>                      