### PR TITLE
sama7g5: add aes support

### DIFF
--- a/device/sama7g5/Config.in.device
+++ b/device/sama7g5/Config.in.device
@@ -4,6 +4,7 @@
 
 config SAMA7G5
 	select CORE_CORTEX_A7
+	select CPU_HAS_AES
 	select CPU_HAS_PIO4
 	select CPU_HAS_SCKC
 	select CPU_HAS_SCLK_BYPASS

--- a/include/arch/sama7g5.h
+++ b/include/arch/sama7g5.h
@@ -17,6 +17,7 @@
 #define AT91C_ID_PIOE		15	/* Parallel I/O Controller E */
 
 #define AT91C_ID_HSMC		21
+#define AT91C_ID_AES		27	/* Advanced Encryption Standard */
 #define AT91C_ID_FLEXCOM0	38
 #define AT91C_ID_FLEXCOM1	39
 #define AT91C_ID_FLEXCOM2	40
@@ -52,6 +53,8 @@
 #define AT91C_BASE_PIOE		(AT91C_BASE_PIOD + 0x40)
 
 #define AT91C_BASE_PMC		0xe0018000
+
+#define AT91C_BASE_AES		0xe1810000
 
 #define AT91C_BASE_WDT		0xe001c000
 #define AT91C_BASE_RSTC		0xe001d000


### PR DESCRIPTION
- Define register ID and address of AES device, according to the datasheet.
- Enable the AES support in the sama7g5 configuration.