### PR TITLE
Fix build failure with GCC 15

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -20,8 +20,11 @@ typedef signed long long s64;
 typedef unsigned long size_t;
 typedef signed long ssize_t;
 
+/* bool, false and true are predefined since C23. */
+#if __STDC_VERSION__ < 202311L
 typedef unsigned char bool;
 #define false	0U
 #define true	1U
+#endif
 
 #endif /* TYPES_H_ */


### PR DESCRIPTION
Building with GCC 15 fails with:

    include/types.h:23:23: error: ‘bool’ cannot be defined via ‘typedef’
       23 | typedef unsigned char bool;
          |                       ^~~~
    include/types.h:23:23: note: ‘bool’ is a keyword with ‘-std=c23’ onwards

This is because GCC 15 default to the C23 dialect of C, which predefines `bool` (and `false` and `true`) as keywords.

This pull request fixes the build failure by conditioning the definitions of `bool`, `false` and `true` on the C dialect in use. Alternative approaches could be:

 * include `<stdbool.h>`, which should work on all C versions since C99 (but is deprecated in C23)
 * request a specific C dialect with the appropriate `-std=…` compiler flag in the Makefile