### PR TITLE
Makefile: fix ncurses availability check

### DIFF
--- a/config/lxdialog/check-lxdialog.sh
+++ b/config/lxdialog/check-lxdialog.sh
@@ -47,7 +47,7 @@ trap "rm -f $tmp" 0 1 2 3 15
 check() {
         $cc -x c - -o $tmp 2>/dev/null <<'EOF'
 #include CURSES_LOC
-main() {}
+int main() {}
 EOF
 	if [ $? != 0 ]; then
 	    echo " *** Unable to find the ncurses libraries or the"       1>&2


### PR DESCRIPTION
gcc 14.2 includes -Wimplicit-int, causing the check-lxdialog.sh script to run into the following compilation error in the check() function:

```
<stdin>:2:1: error: return type defaults to ‘int’ [-Wimplicit-int]
```

This results in the incorrect assumption that ncurses is not available.