### PR TITLE
at91bootstrap-3: Fix build failure with GCC 15

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -42,8 +42,11 @@ typedef signed long long s64;
 typedef unsigned long size_t;
 typedef signed long ssize_t;
 
+/* bool, false and true are predefined since C23. */
+#if __STDC_VERSION__ < 202311L
 typedef unsigned char bool;
 #define false	0U
 #define true	1U
+#endif
 
 #endif /* TYPES_H_ */


### PR DESCRIPTION
This is a backport of commit 32bbb4f73a9f3e94326f709413c1b58baefdfbfa (pull request #188). It targets the branch at91bootstrap-3.x, which has the exact same code in `include/types.h` as the 4.x branch (only the comments differ).