### PR TITLE
lxdialog: make compiler check C99-compliant

### DIFF
--- a/config/lxdialog/check-lxdialog.sh
+++ b/config/lxdialog/check-lxdialog.sh
@@ -47,7 +47,7 @@ trap "rm -f $tmp" 0 1 2 3 15
 check() {
         $cc -x c - -o $tmp 2>/dev/null <<'EOF'
 #include CURSES_LOC
-main() {}
+int main() {}
 EOF
 	if [ $? != 0 ]; then
 	    echo " *** Unable to find the ncurses libraries or the"       1>&2


### PR DESCRIPTION
Current compilers like GCC 14 fail to compile this test program with default settings (unless `-Wno-implicit-int` is given) since function prototypes without return value are not C99-compliant. The result is that ncurses is not found and 'make menuconfig' is not possible.